### PR TITLE
all processes save to and restore from the same dir

### DIFF
--- a/official/resnet/resnet_run_loop.py
+++ b/official/resnet/resnet_run_loop.py
@@ -526,7 +526,7 @@ def resnet_main(
 
   classifier = tf.estimator.Estimator(
       model_fn=model_function, 
-      model_dir=flags_obj.model_dir if exporter else None, 
+      model_dir=flags_obj.model_dir, 
       config=run_config,
       warm_start_from=warm_start_settings, params={
           'resnet_size': int(flags_obj.resnet_size),


### PR DESCRIPTION
To make all the processes train from the same model parameters, set the same model_dir for all processes. It generally works well, but sometimes conflicts happen when saving checkpoints because of multiple writes. In this case, just rerun it from the last checkpoint.

Todo:
There maybe better method to solve this.